### PR TITLE
Fix mim api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * BREAKING: Change DrudeLorentz default plasma frequency to 1.
+* BREAKING: Change function names and parameter orders:
+    * `metal_insulator_metal_collin_approximation` -> `metal_dielectric_metal_collin_approximation`
+    * `metal_insulator_metal_sondergaard_narrow_approximation` -> `metal_dielectric_metal_sondergaard_narrow_approximation`
 
 ### Fixed
 

--- a/examples/scripts/metal_dielectric_metal_approximations.py
+++ b/examples/scripts/metal_dielectric_metal_approximations.py
@@ -1,4 +1,4 @@
-'''Example metal-insulator-metal dispersion approximations example usage'''
+'''Example metal-dielectric-metal dispersion approximations example usage'''
 
 import numpy as np
 import matplotlib
@@ -11,14 +11,14 @@ matplotlib.rc('font', size=12)
 
 collin_approximation_parameters = {
     'wavelength': 1,
-    'insulator_thickness': np.logspace(-2, 1, 100),
+    'thickness': np.logspace(-2, 1, 100),
     'dielectric_permittivity': 1,
     'metal_permittivity': -50,
 }
 
 sondergaard_approximation_parameters = {
     'wavelength': 775,
-    'insulator_thickness': np.arange(1, 3000),
+    'thickness': np.arange(1, 3000),
     'dielectric_permittivity': 1,
     'metal_permittivity': -23.6+1.69j,
 }
@@ -39,7 +39,7 @@ sondergaard_approximation_figure, (sondergaard_approximation_axes) = plt.subplot
 collin_approximation_axes.set_title(
     'Fig. 2 from \nhttps://doi.org/10.1364/OE.15.004310')
 collin_approximation_axes.semilogx(
-    collin_approximation_parameters['insulator_thickness'],
+    collin_approximation_parameters['thickness'],
     collin_approximation.real,
     color='C3',
     label='coupled SPP approx.')
@@ -51,12 +51,12 @@ collin_approximation_axes.set_ylabel(r'Effective index $n_{1D}$')
 collin_approximation_axes.legend()
 collin_approximation_figure.tight_layout()
 collin_approximation_figure.savefig(
-    './images/collin_approximation_example.png')
+    '../images/collin_approximation_example.png')
 
 sondergaard_approximation_axes.set_title(
     'Fig. 4 from \nhttps://doi.org/10.1364/OE.15.010869')
 sondergaard_approximation_axes.plot(
-    sondergaard_approximation_parameters['insulator_thickness'],
+    sondergaard_approximation_parameters['thickness'],
     sondergaard_approximation.real,
     color='C2',
     label='small-gap approximation')

--- a/examples/scripts/metal_insulator_metal_approximations.py
+++ b/examples/scripts/metal_insulator_metal_approximations.py
@@ -27,7 +27,7 @@ collin_approximation = plasmon.metal_dielectric_metal_collin_approximation(
     **collin_approximation_parameters
 )
 
-sondergaard_approximation = plasmon.metal_insulator_metal_sondergaard_narrow_approximation(
+sondergaard_approximation = plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
     **sondergaard_approximation_parameters
 )
 

--- a/examples/scripts/metal_insulator_metal_approximations.py
+++ b/examples/scripts/metal_insulator_metal_approximations.py
@@ -17,10 +17,10 @@ collin_approximation_parameters = {
 }
 
 sondergaard_approximation_parameters = {
-    'dielectric_permittivity': 1,
-    'metal_permittivity': -23.6+1.69j,
     'wavelength': 775,
     'insulator_thickness': np.arange(1, 3000),
+    'dielectric_permittivity': 1,
+    'metal_permittivity': -23.6+1.69j,
 }
 
 collin_approximation = plasmon.metal_dielectric_metal_collin_approximation(

--- a/examples/scripts/metal_insulator_metal_approximations.py
+++ b/examples/scripts/metal_insulator_metal_approximations.py
@@ -10,10 +10,10 @@ from optical_dispersion_relations import plasmon
 matplotlib.rc('font', size=12)
 
 collin_approximation_parameters = {
-    'dielectric_permittivity': 1,
-    'metal_permittivity': -50,
     'wavelength': 1,
     'insulator_thickness': np.logspace(-2, 1, 100),
+    'dielectric_permittivity': 1,
+    'metal_permittivity': -50,
 }
 
 sondergaard_approximation_parameters = {

--- a/examples/scripts/metal_insulator_metal_approximations.py
+++ b/examples/scripts/metal_insulator_metal_approximations.py
@@ -23,7 +23,7 @@ sondergaard_approximation_parameters = {
     'insulator_thickness': np.arange(1, 3000),
 }
 
-collin_approximation = plasmon.metal_insulator_metal_collin_approximation(
+collin_approximation = plasmon.metal_dielectric_metal_collin_approximation(
     **collin_approximation_parameters
 )
 

--- a/examples/scripts/surface_plasmon_polariton.py
+++ b/examples/scripts/surface_plasmon_polariton.py
@@ -15,12 +15,12 @@ METAL_DISPERSION_PARAMETERS = {
 }
 
 
-def drude_metal_surface_plasmon_polariton(frequencies, insulator_permittivity):
+def drude_metal_surface_plasmon_polariton(frequencies, dielectric_permittivity):
     '''Surface plasmon polariton dispersion with simple Drude metal'''
     metal_permittivity = drude_lorentz.single_pole(
         frequencies, **METAL_DISPERSION_PARAMETERS)
     effective_refractive_index = plasmon.surface_plasmon_polariton(
-        insulator_permittivity, metal_permittivity)
+        dielectric_permittivity, metal_permittivity)
     return effective_refractive_index
 
 

--- a/legacy/RI_with_thickness.py
+++ b/legacy/RI_with_thickness.py
@@ -40,7 +40,7 @@ t_sweep = []
 for ti in t_i:
 	# Newton-Raphson process, decreasing gap thickness
     propagation_constant_initial_estimate = k0*plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
-        i_eps, m_eps, wl, ti
+        wl, ti, i_eps, m_eps 
     )
     converged_propagation_constant = opt.newton(
         func=plasmon.transcendential_trilayer_even_magnetic_field,

--- a/legacy/RI_with_thickness.py
+++ b/legacy/RI_with_thickness.py
@@ -39,7 +39,7 @@ t_sweep = []
 
 for ti in t_i:
 	# Newton-Raphson process, decreasing gap thickness
-    propagation_constant_initial_estimate = k0*plasmon.metal_insulator_metal_sondergaard_narrow_approximation(
+    propagation_constant_initial_estimate = k0*plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
         i_eps, m_eps, wl, ti
     )
     converged_propagation_constant = opt.newton(

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -34,20 +34,20 @@ def surface_plasmon_polariton(
 
 
 def metal_dielectric_metal_collin_approximation(
+    wavelength: float,
+    thickness: float,
     dielectric_permittivity: float,
     metal_permittivity: complex,
-    wavelength: float,
-    thickness: float
 ) -> complex:
     """Approximate dispersion relation for a finite-thickness dielectric slab
     between two semi-infinite metal half-spaces. TM polarization.
 
     Parameters
     ----------
-    dielectric_permittivity: float or complex
-    metal_permittivity: float or complex
     wavelength, in any unit of distance: float
     thickness, in the same unit of distance as wavelength: float
+    dielectric_permittivity: float or complex
+    metal_permittivity: float or complex
 
     Returns
     -------

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -66,7 +66,7 @@ def metal_dielectric_metal_collin_approximation(
     return effective_refractive_index
 
 
-def metal_insulator_metal_sondergaard_narrow_approximation(
+def metal_dielectric_metal_sondergaard_narrow_approximation(
     dielectric_permittivity: float,
     metal_permittivity: complex,
     wavelength: float,

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -37,7 +37,7 @@ def metal_dielectric_metal_collin_approximation(
     dielectric_permittivity: float,
     metal_permittivity: complex,
     wavelength: float,
-    insulator_thickness: float
+    thickness: float
 ) -> complex:
     """Approximate dispersion relation for a finite-thickness dielectric slab
     between two semi-infinite metal half-spaces. TM polarization.
@@ -47,7 +47,7 @@ def metal_dielectric_metal_collin_approximation(
     dielectric_permittivity: float or complex
     metal_permittivity: float or complex
     wavelength, in any unit of distance: float
-    insulator_thickness, in the same unit of distance as wavelength: float
+    thickness, in the same unit of distance as wavelength: float
 
     Returns
     -------
@@ -60,7 +60,7 @@ def metal_dielectric_metal_collin_approximation(
     """
     surface_plasmon_coupling_term = wavelength * \
         np.sqrt(1-dielectric_permittivity/metal_permittivity) / \
-        (np.pi*insulator_thickness*np.sqrt(-1*metal_permittivity))
+        (np.pi*thickness*np.sqrt(-1*metal_permittivity))
     effective_refractive_index = np.sqrt(dielectric_permittivity) * \
         np.sqrt(1 + surface_plasmon_coupling_term)
     return effective_refractive_index

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -33,13 +33,14 @@ def surface_plasmon_polariton(
     return effective_refractive_index
 
 
-def metal_insulator_metal_collin_approximation(
+def metal_dielectric_metal_collin_approximation(
     dielectric_permittivity: float,
     metal_permittivity: complex,
     wavelength: float,
     insulator_thickness: float
 ) -> complex:
-    """Approximate metal-insulator-metal waveguide dispersion relation for TM polarization.
+    """Approximate dispersion relation for a finite-thickness dielectric slab
+    between two semi-infinite metal half-spaces. TM polarization.
 
     Parameters
     ----------

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -67,20 +67,20 @@ def metal_dielectric_metal_collin_approximation(
 
 
 def metal_dielectric_metal_sondergaard_narrow_approximation(
+    wavelength: float,
+    thickness: float,
     dielectric_permittivity: float,
     metal_permittivity: complex,
-    wavelength: float,
-    thickness: float
 ) -> complex:
     """Approximate dispersion relation for a finite-thickness dielectric slab
     between two semi-infinite metal half-spaces. TM polarization.
 
     Parameters
     ----------
-    dielectric_permittivity: float or complex
-    metal_permittivity: float or complex
     wavelength: float, in any unit of distance
     thickness: float, of the insulatr layer in the same unit of distance as wavelength
+    dielectric_permittivity: float or complex
+    metal_permittivity: float or complex
 
     Returns
     -------

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -70,16 +70,17 @@ def metal_dielectric_metal_sondergaard_narrow_approximation(
     dielectric_permittivity: float,
     metal_permittivity: complex,
     wavelength: float,
-    insulator_thickness: float
+    thickness: float
 ) -> complex:
-    """Approximate metal-insulator-metal waveguide dispersion relation for TM polarization.
+    """Approximate dispersion relation for a finite-thickness dielectric slab
+    between two semi-infinite metal half-spaces. TM polarization.
 
     Parameters
     ----------
     dielectric_permittivity: float or complex
     metal_permittivity: float or complex
     wavelength: float, in any unit of distance
-    insulator_thickness: float, in the same unit of distance as wavelength
+    thickness: float, of the insulatr layer in the same unit of distance as wavelength
 
     Returns
     -------
@@ -93,7 +94,7 @@ def metal_dielectric_metal_sondergaard_narrow_approximation(
     freespace_wavenumber = utilities.wavelength_to_wavenumber(wavelength)
 
     narrow_gap_limit_propagation_constant = -2 * dielectric_permittivity \
-        / (insulator_thickness * metal_permittivity)
+        / (thickness * metal_permittivity)
 
     narrow_gap_limit_effective_refractive_index = narrow_gap_limit_propagation_constant \
         / freespace_wavenumber

--- a/optical_dispersion_relations/plasmon.py
+++ b/optical_dispersion_relations/plasmon.py
@@ -121,7 +121,7 @@ def transcendential_trilayer_even_magnetic_field(
     middle_layer_permittivity: 'float | complex',
     outer_layers_permittivity: 'float | complex',
 ) -> complex:
-    """Describes a metal-insulator-metal or insulator-metal-insulator symmetrical stack,
+    """Describes a metal-dielectric-metal or dielectric-metal-dielectric symmetrical stack,
     odd vector parity modes / the magnetic field is an even function.
 
     Parameters
@@ -168,7 +168,7 @@ def transcendential_trilayer_odd_magnetic_field(
     middle_layer_permittivity: 'float | complex',
     outer_layers_permittivity: 'float | complex',
 ) -> complex:
-    """Describes a metal-insulator-metal or insulator-metal-insulator symmetrical stack,
+    """Describes a metal-dielectric-metal or dielectric-metal-dielectric symmetrical stack,
     even vector parity modes / the magnetic field is an odd function.
 
     Parameters

--- a/test/test_plasmon.py
+++ b/test/test_plasmon.py
@@ -61,7 +61,7 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
         expected_effective_refractive_index = 1
 
         # When
-        actual_effective_refractive_index = plasmon.metal_insulator_metal_collin_approximation(
+        actual_effective_refractive_index = plasmon.metal_dielectric_metal_collin_approximation(
             dielectric_permittivity=dielectric_permittivity,
             metal_permittivity=metal_permittivity,
             wavelength=wavelength,
@@ -83,7 +83,7 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
         expected_effective_refractive_index = 2.355
 
         # When
-        actual_effective_refractive_index = plasmon.metal_insulator_metal_collin_approximation(
+        actual_effective_refractive_index = plasmon.metal_dielectric_metal_collin_approximation(
             dielectric_permittivity=dielectric_permittivity,
             metal_permittivity=metal_permittivity,
             wavelength=wavelength,

--- a/test/test_plasmon.py
+++ b/test/test_plasmon.py
@@ -118,10 +118,10 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
         # When
         actual_effective_refractive_index = \
             plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
-                dielectric_permittivity=dielectric_permittivity,
-                metal_permittivity=metal_permittivity,
                 wavelength=wavelength,
                 thickness=thickness,
+                dielectric_permittivity=dielectric_permittivity,
+                metal_permittivity=metal_permittivity,
             )
 
         # Then
@@ -140,10 +140,10 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
         # When
         actual_effective_refractive_index = \
             plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
-                dielectric_permittivity=dielectric_permittivity,
-                metal_permittivity=metal_permittivity,
                 wavelength=wavelength,
                 thickness=insulator_thickness,
+                dielectric_permittivity=dielectric_permittivity,
+                metal_permittivity=metal_permittivity,
             )
 
         # Then
@@ -166,10 +166,10 @@ class TranscendentialTrilayerEven(unittest.TestCase):
         thickness = 100
 
         approx_refractive_index = plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
-            dielectric_permittivity,
-            metal_permittivity,
             wavelength,
             thickness,
+            dielectric_permittivity,
+            metal_permittivity,
         )
 
         wavenumber = utilities.wavelength_to_wavenumber(wavelength)

--- a/test/test_plasmon.py
+++ b/test/test_plasmon.py
@@ -62,10 +62,10 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
 
         # When
         actual_effective_refractive_index = plasmon.metal_dielectric_metal_collin_approximation(
-            dielectric_permittivity=dielectric_permittivity,
-            metal_permittivity=metal_permittivity,
             wavelength=wavelength,
             thickness=thickness,
+            dielectric_permittivity=dielectric_permittivity,
+            metal_permittivity=metal_permittivity,
         )
 
         # Then
@@ -84,10 +84,10 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
 
         # When
         actual_effective_refractive_index = plasmon.metal_dielectric_metal_collin_approximation(
-            dielectric_permittivity=dielectric_permittivity,
-            metal_permittivity=metal_permittivity,
             wavelength=wavelength,
             thickness=thickness,
+            dielectric_permittivity=dielectric_permittivity,
+            metal_permittivity=metal_permittivity,
         )
 
         # Then

--- a/test/test_plasmon.py
+++ b/test/test_plasmon.py
@@ -107,7 +107,7 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
         dielectric_permittivity = 1
         metal_permittivity = -23.6+1.69j
         wavelength = 775
-        insulator_thickness = np.array([100, 200, 300, 400, 500])
+        thickness = np.array([100, 200, 300, 400, 500])
 
         expected_effective_refractive_index = np.array([1.23403843+0.00811681j,
                                                         1.12252228+0.00437417j,
@@ -121,7 +121,7 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
                 dielectric_permittivity=dielectric_permittivity,
                 metal_permittivity=metal_permittivity,
                 wavelength=wavelength,
-                insulator_thickness=insulator_thickness,
+                thickness=thickness,
             )
 
         # Then
@@ -143,7 +143,7 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
                 dielectric_permittivity=dielectric_permittivity,
                 metal_permittivity=metal_permittivity,
                 wavelength=wavelength,
-                insulator_thickness=insulator_thickness,
+                thickness=insulator_thickness,
             )
 
         # Then

--- a/test/test_plasmon.py
+++ b/test/test_plasmon.py
@@ -117,7 +117,7 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
 
         # When
         actual_effective_refractive_index = \
-            plasmon.metal_insulator_metal_sondergaard_narrow_approximation(
+            plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
                 dielectric_permittivity=dielectric_permittivity,
                 metal_permittivity=metal_permittivity,
                 wavelength=wavelength,
@@ -139,7 +139,7 @@ class MetalInsulatorMetalSondergaardNarrowApproximation(unittest.TestCase):
 
         # When
         actual_effective_refractive_index = \
-            plasmon.metal_insulator_metal_sondergaard_narrow_approximation(
+            plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
                 dielectric_permittivity=dielectric_permittivity,
                 metal_permittivity=metal_permittivity,
                 wavelength=wavelength,
@@ -165,7 +165,7 @@ class TranscendentialTrilayerEven(unittest.TestCase):
         wavelength = 775
         thickness = 100
 
-        approx_refractive_index = plasmon.metal_insulator_metal_sondergaard_narrow_approximation(
+        approx_refractive_index = plasmon.metal_dielectric_metal_sondergaard_narrow_approximation(
             dielectric_permittivity,
             metal_permittivity,
             wavelength,

--- a/test/test_plasmon.py
+++ b/test/test_plasmon.py
@@ -51,11 +51,11 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
     https://doi.org/10.1364/OE.15.004310
     """
 
-    def test_thick_insulator(self):
+    def test_thick_dielectric(self):
         # Given
         dielectric_permittivity = 1
         metal_permittivity = -50
-        insulator_thickness = 10
+        thickness = 10
         wavelength = 1
 
         expected_effective_refractive_index = 1
@@ -65,7 +65,7 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
             dielectric_permittivity=dielectric_permittivity,
             metal_permittivity=metal_permittivity,
             wavelength=wavelength,
-            insulator_thickness=insulator_thickness,
+            thickness=thickness,
         )
 
         # Then
@@ -73,11 +73,11 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
                                actual_effective_refractive_index,
                                places=2)
 
-    def test_thin_insulator(self):
+    def test_thin_dielectric(self):
         # Given
         dielectric_permittivity = 1
         metal_permittivity = -50
-        insulator_thickness = 0.01
+        thickness = 0.01
         wavelength = 1
 
         expected_effective_refractive_index = 2.355
@@ -87,7 +87,7 @@ class MetalInsulatorMetalCollinApproximation(unittest.TestCase):
             dielectric_permittivity=dielectric_permittivity,
             metal_permittivity=metal_permittivity,
             wavelength=wavelength,
-            insulator_thickness=insulator_thickness,
+            thickness=thickness,
         )
 
         # Then


### PR DESCRIPTION
Aims to make the MIM approximations api consistent with the rest of the library by:
* Replacing `insulator` with `dielectric`,
* Ordering arguments consistent with other library functions.